### PR TITLE
Add checkpoint functionality for scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ scanner.Start(ddb.HandlerFunc(func(items ddb.Items) {
 scanner.Wait()
 ```
 
+Leverage a checkpoint table to store the last evaluated key of a scan:
+
+```go
+scanner := ddb.NewScanner(ddb.Config{
+    TableName:           "ddb-table-name",
+    CheckpointTableName: "checkpoint-production",  // name of table to store last evaluated keys
+    CheckpointNamespace: "my-sample-app",          // namespace to avoid collisions with other scripts
+    TotalSegments:       150,
+})
+```
+
 ## License
 
 go-ddb is copyright © 2016 Clearbit. It is free software, and may

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -1,0 +1,89 @@
+package ddb
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+// Checkpoint wraps the interactions with dynamo for setting/getting checkpoints
+type Checkpoint struct {
+	Svc       *dynamodb.DynamoDB
+	Namespace string
+	TableName string
+}
+
+// row reprsents a record in dynamodb table
+type row struct {
+	Namespace        string           `json:"namespace"`
+	Segment          int              `json:"segment"`
+	LastEvaluatedKey LastEvaluatedKey `json:"last_evaluated_key"`
+}
+
+// LastEvaluatedKey is the attribute value of the last evaluated key in a scan
+type LastEvaluatedKey map[string]*dynamodb.AttributeValue
+
+// Get returns the exclusive start key for current segment
+func (c *Checkpoint) Get(segment int) LastEvaluatedKey {
+	resp, err := c.Svc.GetItem(&dynamodb.GetItemInput{
+		TableName:      aws.String(c.TableName),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]*dynamodb.AttributeValue{
+			"namespace": &dynamodb.AttributeValue{
+				S: aws.String(c.Namespace),
+			},
+			"segment": &dynamodb.AttributeValue{
+				N: aws.String(strconv.Itoa(segment)),
+			},
+		},
+	})
+	if err != nil {
+		if retriableError(err) {
+			c.Get(segment)
+		} else {
+			fmt.Printf("Checkpoint > Get > GetItem: %v", err)
+			return nil
+		}
+	}
+	item := row{}
+	dynamodbattribute.UnmarshalMap(resp.Item, &item)
+	return item.LastEvaluatedKey
+}
+
+// Set the lastEvaluatedKey as most recent checkpoint
+func (c *Checkpoint) Set(segment int, lastEvaluatedKey LastEvaluatedKey) {
+	item, err := dynamodbattribute.MarshalMap(row{
+		Namespace:        c.Namespace,
+		Segment:          segment,
+		LastEvaluatedKey: lastEvaluatedKey,
+	})
+	if err != nil {
+		fmt.Printf("Checkpoint > Set > MarshalMap: %v", err)
+		return
+	}
+	_, err = c.Svc.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(c.TableName),
+		Item:      item,
+	})
+	if err != nil {
+		if retriableError(err) {
+			c.Set(segment, lastEvaluatedKey)
+		} else {
+			fmt.Printf("Checkpoint > Set > PutItem: %v", err)
+		}
+	}
+	return
+}
+
+func retriableError(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == "ProvisionedThroughputExceededException" {
+			return true
+		}
+	}
+	return false
+}

--- a/config.go
+++ b/config.go
@@ -1,9 +1,7 @@
 package ddb
 
 import (
-	"expvar"
 	"log"
-	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -12,22 +10,25 @@ import (
 
 const (
 	defaultAwsRegion     = "us-west-1"
-	defaultTotalSegments = 100
+	defaultTotalSegments = 50
 )
 
 // Config is wrapper around the configuration variables
 type Config struct {
-	// CompletedSegments tracks how many of segments have completed
-	CompletedSegments *expvar.Int
+	// Svc the dynamodb connection
+	Svc *dynamodb.DynamoDB
 
-	// TotalProcessed counts the number of items pullsed from DB
-	TotalProcessed *expvar.Int
-
-	// WaitGroup for tracking completed segments
-	WaitGroup *sync.WaitGroup
+	// AwsRegion is the region the database is in. Defaults to us-west-1
+	AwsRegion string
 
 	// TableName is name of table to scan
 	TableName string
+
+	// TotalSegments determines amount of concurrency to scan table with
+	TotalSegments int
+
+	// Checkpoint
+	Checkpoint *Checkpoint
 
 	// CheckpointTableName is the name of checkpont table
 	CheckpointTableName string
@@ -35,40 +36,20 @@ type Config struct {
 	// CheckpointNamespace is the unique namespace for checkpoints. This must be unique so
 	// checkpoints so differnt scripts can maintain their own checkpoints.
 	CheckpointNamespace string
-
-	// TotalSegments determines amount of concurrency to scan table with
-	TotalSegments int
-
-	// AwsRegion is the region the database is in. Defaults to us-west-1
-	AwsRegion string
-
-	// Checkpoint
-	Checkpoint *Checkpoint
-
-	// svc the dynamodb connection
-	Svc *dynamodb.DynamoDB
 }
 
 // defaults for configuration.
 func (c *Config) setDefaults() {
-	if c.TableName == "" {
-		log.Fatal("TableName required as config var")
-	}
-
-	if c.WaitGroup == nil {
-		c.WaitGroup = &sync.WaitGroup{}
-	}
-
 	if c.AwsRegion == "" {
 		c.AwsRegion = defaultAwsRegion
 	}
 
-	if c.CompletedSegments == nil {
-		c.CompletedSegments = expvar.NewInt("completed_segments")
+	if c.TableName == "" {
+		log.Fatal("TableName required as config var")
 	}
 
-	if c.TotalProcessed == nil {
-		c.TotalProcessed = expvar.NewInt("total_processed")
+	if c.TotalSegments == 0 {
+		c.TotalSegments = defaultTotalSegments
 	}
 
 	if c.Svc == nil {


### PR DESCRIPTION
When scanning large tables often we'll want to store a checkpoint for
the last evaluated item from DynamoDB. This will allow our scans to
continue where they left off the next time the script runs.

Implements #1